### PR TITLE
Simple functions that don't need passing around handles, only filenames or file contents #17

### DIFF
--- a/System/IO/Temp.hs
+++ b/System/IO/Temp.hs
@@ -2,7 +2,7 @@ module System.IO.Temp (
     withSystemTempFile, withSystemTempDirectory,
     withTempFile, withTempDirectory,
     module Distribution.Compat.TempFile,
-    writeTempFile
+    writeTempFile, writeSystemTempFile
   ) where
 
 -- NB: this module was extracted directly from "Distribution/Simple/Utils.hs"
@@ -82,8 +82,8 @@ withTempDirectory targetDir template =
     (liftIO . ignoringIOErrors . removeDirectoryRecursive)
 
 
--- | Create a unique new file, write a given data string to it, and
---   close the handle again. The file will not be deleted automatically,
+-- | Create a unique new file, write (text mode) a given data string to it,
+--   and close the handle again. The file will not be deleted automatically,
 --   and only the current user will have permission to access the file
 --   (see `openTempFile` for details).
 writeTempFile :: FilePath    -- ^ Directory in which to create the file
@@ -95,6 +95,12 @@ writeTempFile targetDir template content = Exception.bracket
     (\(_, handle) -> hClose handle)
     (\(filePath, handle) -> hPutStr handle content >> return filePath)
 
+-- | Like 'writeTempFile', but use the system directory for temporary files.
+writeSystemTempFile :: String      -- ^ File name template.
+                    -> String      -- ^ Data to store in the file.
+                    -> IO FilePath -- ^ Path to the (written and closed) file.
+writeSystemTempFile template content
+    = getTemporaryDirectory >>= \tmpDir -> writeTempFile tmpDir template content
 
 
 ignoringIOErrors :: MonadCatch m => m () -> m ()

--- a/System/IO/Temp.hs
+++ b/System/IO/Temp.hs
@@ -2,7 +2,8 @@ module System.IO.Temp (
     withSystemTempFile, withSystemTempDirectory,
     withTempFile, withTempDirectory,
     module Distribution.Compat.TempFile,
-    writeTempFile, writeSystemTempFile
+    writeTempFile, writeSystemTempFile,
+    emptyTempFile, emptySystemTempFile
   ) where
 
 -- NB: this module was extracted directly from "Distribution/Simple/Utils.hs"
@@ -101,6 +102,22 @@ writeSystemTempFile :: String      -- ^ File name template.
                     -> IO FilePath -- ^ Path to the (written and closed) file.
 writeSystemTempFile template content
     = getTemporaryDirectory >>= \tmpDir -> writeTempFile tmpDir template content
+
+-- | Create a unique new empty file. (Equivalent to 'writeTempFile' with empty data string.)
+--   This is useful if the actual content is provided by an external process.
+emptyTempFile :: FilePath    -- ^ Directory in which to create the file
+              -> String      -- ^ File name template.
+              -> IO FilePath -- ^ Path to the (written and closed) file.
+emptyTempFile targetDir template = Exception.bracket
+    (openTempFile targetDir template)
+    (\(_, handle) -> hClose handle)
+    (\(filePath, handle) -> return filePath)
+
+-- | Like 'emptyTempFile', but use the system directory for temporary files.
+emptySystemTempFile :: String      -- ^ File name template.
+                    -> IO FilePath -- ^ Path to the (written and closed) file.
+emptySystemTempFile template
+    = getTemporaryDirectory >>= \tmpDir -> emptyTempFile tmpDir template
 
 
 ignoringIOErrors :: MonadCatch m => m () -> m ()


### PR DESCRIPTION
cf. https://github.com/batterseapower/temporary/pull/17

The `withTempFile` functions are useful for serious work with file handles, but this is awkward if all you want to do is dump some data and be sure you don't overwrite anything. `writeTempFile` now does just that.

Furthermore: not always can you actually generate a file from within Haskell, like `openTempFile` prepares for us.  Sometimes, the actual file must be generated by an external library- or even process call, which can't use handles but just needs a target file name. I added a function which only uses the functionality to generate such unique-new file names, but <del>doesn't actually generate any files</del> doesn't put in any content, relegating this to a supplied action.

<del>(Actually the implementation is a bit more hackish: it generates a temporary file with `openTempFile`, immediately deletes it and uses the file name for whatever the user needs it to.)</del>